### PR TITLE
Fix for dialog closing crash

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -504,7 +504,12 @@ public class InAppBrowser extends CordovaPlugin {
                     // NB: wait for about:blank before dismissing
                     public void onPageFinished(WebView view, String url) {
                         if (dialog != null) {
-                            dialog.dismiss();
+                            // https://stackoverflow.com/questions/22924825/view-not-attached-to-window-manager-crash
+                            if (Build.VERSION.SDK_INT < 17 && !cordova.getActivity().isFinishing()) {
+                                dialog.dismiss();
+                            } else if (Build.VERSION.SDK_INT >= 17 && !cordova.getActivity().isDestroyed()) {
+                                dialog.dismiss();
+                            }
                             dialog = null;
                         }
                     }


### PR DESCRIPTION
Happens when activity is already gone.
- https://console.firebase.google.com/project/easy-ebt-balance/monitoring/app/android:com.propel.ebenefits/cluster/97c33b61?duration=2592000000
- https://stackoverflow.com/questions/22924825/view-not-attached-to-window-manager-crash