### PR TITLE
Fix iOS 12 double loading bug

### DIFF
--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -33,7 +33,7 @@
 }
 
 @property (nonatomic, retain) CDVInAppBrowserViewController* inAppBrowserViewController;
-@property (nonatomic, copy) NSDictionary* urlLoadMap;
+@property (nonatomic, copy) NSString* loadedUrl;
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -33,6 +33,7 @@
 }
 
 @property (nonatomic, retain) CDVInAppBrowserViewController* inAppBrowserViewController;
+@property (nonatomic, copy) NSDictionary* urlLoadMap;
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -157,7 +157,7 @@ static NSString *urlEncode(id object) {
     NSString* options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
 
     self.callbackId = command.callbackId;
-    self.urlLoadMap = @{};
+    self.loadedUrl = @"";
 
     if (url != nil) {
 #ifdef __CORDOVA_4_0_0
@@ -772,11 +772,11 @@ static NSString *urlEncode(id object) {
         }
     }
     else if ((self.callbackId != nil) && isTopLevelNavigation) {
-        NSString *loadedUrl = [self.urlLoadMap objectForKey:@"loadstart"];
-        if ([loadedUrl isEqualToString:[url absoluteString]]) {
-            self.urlLoadMap = @{};
+        if ([self.loadedUrl isEqualToString:[url absoluteString]]) {
+            self.loadedUrl = @"";
             return NO;
         }
+        self.loadedUrl = [url absoluteString];
 
         // Send a loadstart event for each top-level navigation (includes redirects).
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -784,8 +784,6 @@ static NSString *urlEncode(id object) {
         [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
 
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-
-        self.urlLoadMap = @{@"loadstart":[url absoluteString]};
     }
 
     return YES;

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -157,6 +157,7 @@ static NSString *urlEncode(id object) {
     NSString* options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
 
     self.callbackId = command.callbackId;
+    self.urlLoadMap = @{};
 
     if (url != nil) {
 #ifdef __CORDOVA_4_0_0
@@ -771,12 +772,20 @@ static NSString *urlEncode(id object) {
         }
     }
     else if ((self.callbackId != nil) && isTopLevelNavigation) {
+        NSString *loadedUrl = [self.urlLoadMap objectForKey:@"loadstart"];
+        if ([loadedUrl isEqualToString:[url absoluteString]]) {
+            self.urlLoadMap = @{};
+            return NO;
+        }
+
         // Send a loadstart event for each top-level navigation (includes redirects).
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                       messageAsDictionary:@{@"type":@"loadstart", @"url":[url absoluteString]}];
         [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
 
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+
+        self.urlLoadMap = @{@"loadstart":[url absoluteString]};
     }
 
     return YES;


### PR DESCRIPTION
In iOS 12, this function sometimes gets called twice for some reason: https://github.com/propelinc/cordova-plugin-inappbrowser/blob/master/src/ios/CDVInAppBrowser.m#L1289

As a result, this function gets called twice in a row: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L275

The first time it's called, it hits this case, and `_loadCount` goes to `1`: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L289

The second time it's called, it hits this case, and `_loadCount` goes to `2`: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L298

Then, this function gets called: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L319

It hits this case, but the callback is never fired since `_loadCount` is `2`: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L331

The callback that never gets called is this one, which we rely on to retrieve the contents of the page: https://github.com/propelinc/cordova-plugin-inappbrowser/blob/master/src/ios/CDVInAppBrowser.m#L799

By returning `NO` in `shouldStartLoadWithRequest ` when we've already returned `YES` for that URL, we prevent the double `webViewDidStartLoad` call and the double `_loadCount` increment.