### PR TITLE
change exit emission to only occur after dialog = null

### DIFF
--- a/src/ios/CDVLocalTunnel.m
+++ b/src/ios/CDVLocalTunnel.m
@@ -831,17 +831,22 @@ static NSString *urlEncode(id object) {
 
 - (void)tunnelExit
 {
+    // Set navigationDelegate to nil to ensure no callbacks are received from it.
+    self.localTunnelViewController.navigationDelegate = nil;
+    // Don't recycle the ViewController since it may be consuming a lot of memory.
+    // Also - this is required for the PDF/User-Agent bug work-around.
+    self.localTunnelViewController = nil;
+
+    // NOTE(Alex) We want to avoid race conditions where "exit" event happens before view controller
+    // is set to nil. This would happen if the sendPluginResult yeilds to the javascript call. To
+    // avoid any weirdness around erroneous localTunnelViewSetting, I have moved the
+    // sendPluginResult call to after we have set the localTunnelViewController to nil
     if (self.callbackId != nil) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                       messageAsDictionary:@{@"type":@"exit"}];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
         self.callbackId = nil;
     }
-    // Set navigationDelegate to nil to ensure no callbacks are received from it.
-    self.localTunnelViewController.navigationDelegate = nil;
-    // Don't recycle the ViewController since it may be consuming a lot of memory.
-    // Also - this is required for the PDF/User-Agent bug work-around.
-    self.localTunnelViewController = nil;
 
     if (IsAtLeastiOSVersion(@"7.0")) {
         if (_previousStatusBarStyle != -1) {

--- a/www/localtunnel.js
+++ b/www/localtunnel.js
@@ -51,7 +51,7 @@
                 // can be fully cleaned up
                 var handler = (function () {
                     this.removeEventListener('exit', handler);
-                    setTimeout(resolve, 0);
+                    resolve();
                 }).bind(this);
 
                 this.addEventListener('exit', handler);


### PR DESCRIPTION
**Context**

This is a follow up to this pr: https://github.com/propelinc/cordova-plugin-inappbrowser/pull/8/files

I realized when trying to integrate my fix back in with freshcard that the fix from the previous pr was not fully correct. I was still seeing the recaptcha page not show up some of the time. 

The issue was that setting dialog to null was happening in the an `onPageFinished` callback. This callback sometimes occured after we had started opening the captcha page. (See comment for more indepth description). 

This pr does two things to fix the issue:
1. It moves exit emission into the `onPageFinished` call
2. It stops using `setTimeout` to call resolve since resolve should just now work.