### PR TITLE
Fix recaptcha detection on iOS.

### DIFF
--- a/src/ios/CDVLocalTunnel.m
+++ b/src/ios/CDVLocalTunnel.m
@@ -746,6 +746,7 @@ static NSString *urlEncode(id object) {
         [self.localTunnelViewController navigateTo:actualUrl];
         return NO;
     }
+    // Attempt to detect a redirect when making a localtunnel request.
     else if (requestUrl != nil && ![url isEqual:requestUrl] && ![[url absoluteString] isEqualToString:@"about:blank"]) {
         if (self.callbackId != nil && [[url absoluteString] containsString:@"www.google.com/recaptcha"]) {
             NSLog(@"---- DETECTED REDIRECT TO RECAPTCHA.");

--- a/src/ios/CDVLocalTunnel.m
+++ b/src/ios/CDVLocalTunnel.m
@@ -749,6 +749,9 @@ static NSString *urlEncode(id object) {
     // Attempt to detect a redirect when making a localtunnel request.
     else if (requestUrl != nil && ![url isEqual:requestUrl] && ![[url absoluteString] isEqualToString:@"about:blank"]) {
         if (self.callbackId != nil && [[url absoluteString] containsString:@"www.google.com/recaptcha"]) {
+            // We do not allow the recaptcha page to load because we need the incapsula (you are a robots) page
+            // to be returned to the server for our recaptcha flow to fully work. The browser issued redirect to
+            // recaptcha breaks this pattern.
             NSLog(@"---- DETECTED REDIRECT TO RECAPTCHA.");
             enableRequestBlocking = false;
             NSArray* cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:requestUrl];
@@ -834,6 +837,7 @@ static NSString *urlEncode(id object) {
 {
     NSString* url = [self.localTunnelViewController.currentURL absoluteString];
     if ([url containsString:@"chfs.non-pci.portmapper.vip"]) {
+        // Expired password page loads as expected but an erroneous error is being thrown by iOS.
         NSLog(@"webView:didFailLoadWithError - Suppress load error for OK password reset internal redirect portal bug.");
         return;
     }


### PR DESCRIPTION
By default, iOS automatically redirects all the way to the google recaptcha page. This change prevents that from happening and instead uses the servers incapsula detection to trigger displaying the captcha instead (without request blocking). This makes it the implementation behave the same way as Android, and captcha solving works as expected.