### PR TITLE
Allow ajax post requests from android webview.

### DIFF
--- a/src/android/LocalTunnelChromeClient.java
+++ b/src/android/LocalTunnelChromeClient.java
@@ -120,6 +120,10 @@ public class LocalTunnelChromeClient extends WebChromeClient {
                     this.webView.sendPluginResult(scriptResult, scriptCallbackId);
                     result.confirm("");
                     return true;
+                } else if (scriptCallbackId.startsWith("requestdone")) {
+                    this.iab.sendRequestDone();
+                    result.confirm("");
+                    return true;
                 }
             }
             else


### PR DESCRIPTION
We use [webView.postUrl](https://developer.android.com/reference/android/webkit/WebView#postUrl(java.lang.String,%20byte[]) to make POST request. Unfortunately, this does not allow changing the content-type header. To get around this, we inject javascript to perform the POST request as an ajax request.