### PR TITLE
Make post requests work

### DIFF
--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -259,7 +259,6 @@ protocol WebViewPropagateDelegate {
             let currentURL = self.webViewController?.webView.url?.absoluteString
 
             self.webViewController?.getCookiesForUrl(currentURL ?? "", completionHandler: {cookies in
-                print("Cookies \(cookies)")
                 let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: [
                     "type": "requestdone",
                     "url": currentURL,


### PR DESCRIPTION
The goal of this pr was to get the WKWebview in feature parity with the Android webview. That means that I need to ensure that all the webdriving code ram just added to freshebt-server (https://github.com/propelinc/freshebt-server/pull/1295/files) works in my code.  To accomplish this I needed to do two things:

1. Enable json post requests

2. Make the clearcookies open synchronous

3. Run all requests through the WKWebview when we are trying to do webdriving. This is because of WKWebviews shitty cookie management. If we try and make the requests through urlSession, no all of the htppOnly cookies are getting added to the HTTPCookieStore. So this is a workaround, but it is a workaround that works!