### PR TITLE
fix WKWebview's usage of load and loadHTMLString. Need to set the baseURL not just any url

### DIFF
--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -921,6 +921,10 @@ func convertStringToCookies(_ cookieString: String, host: String) -> [HTTPCookie
     return cookies
 }
 
+// BaseURLs are important because of how webView.load(data, ...
+// and webView.loadHTMLString(... work. Both require that the URL argument
+// is a base url that helps resolve relative URLs in the html body.
+// https://developer.apple.com/documentation/webkit/wkwebview/1415011-load
 func createBaseURL(_ url: URL) -> URL {
     let urlString = url.absoluteString
     let parts = urlString.components(separatedBy: "://")

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -148,7 +148,7 @@ protocol WebViewPropagateDelegate {
                         self.webViewController?.urlSessionLoad(request, requestOptions: self.requestOptions)
                     }
                 } else if self.requestOptions?.requestType == CAPTCHA_REQUEST {
-                    self.webViewController?.loadHTMLString(self.requestOptions?.captchaContentHtml ?? "", baseURL: URL(string: self.requestOptions?.url ?? ""))
+                    self.webViewController?.loadHTMLString(self.requestOptions?.captchaContentHtml ?? "", baseURL: createBaseURL(URL(string: self.requestOptions?.url ?? "")!))
                 }
             }
 
@@ -525,7 +525,7 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
             if error == nil && url != nil && response != nil {
                 self.propagateDelegate.requestStatus = response!.statusCode
                 DispatchQueue.main.async {
-                    self.webView.load(data!, mimeType: "text/html", characterEncodingName: "utf8", baseURL: url!)
+                    self.webView.load(data!, mimeType: "text/html", characterEncodingName: "utf8", baseURL: createBaseURL(url!))
                 }
             } else if error != nil {
                 self.propagateDelegate.requestDidFail(request: request, error: error!)
@@ -919,6 +919,13 @@ func convertStringToCookies(_ cookieString: String, host: String) -> [HTTPCookie
     }
 
     return cookies
+}
+
+func createBaseURL(_ url: URL) -> URL {
+    let urlString = url.absoluteString
+    let parts = urlString.components(separatedBy: "://")
+    let hostname = parts[1].split(separator: "/")[0]
+    return URL(string: "\(parts[0])://\(hostname)")!
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION
@ckuang and I were seeing issues where the response we were getting from `urlSessionLoad` was not properly displaying in the webview when we tried to call `self.webview.load(data!...`. 

After rereading the docs for [load](https://developer.apple.com/documentation/webkit/wkwebview/1415011-load) and [loadHtmlString](https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring) both seem to imply that the url you set should be the base url for the site. That url will be used to load relative URLs. 

For our login request in xerox (and ilinoise because it uses xerox's login) our post request url is: `https://<hostname>/siteLogonClient.recip;jsessionid=<jsession_id>`. This is very different then every other URL we would try and load into the the webview so I suspected that might be the issue. 

To fix the problems for this case and all cases moving forward, I made a small helper function to return the baaseURL for any passed URL. This returned baseURL can then be used as the argument to `load` and `loadHTMLString`. 