### PR TITLE
fix relative redirect to not have an optional in it

### DIFF
--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -579,8 +579,8 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
 
                                 let location = headers["Location"] as! String
                                 var redirectRequest: URLRequest
-                                if location.starts(with: "/") {
-                                    redirectRequest = createRequest(urlString: "\(request.url?.host)\(location)", method: "GET")
+                                if location.starts(with: "/") && request.url?.host != nil {
+                                    redirectRequest = createRequest(urlString: "https://\(request.url!.host!)\(location)", method: "GET")
                                 } else {
                                     redirectRequest = createRequest(urlString: location, method: "GET")
                                 }


### PR DESCRIPTION
Card: https://app.asana.com/0/1158105657996916/1196941843719065

The issue was that i had written the relative redirect logic incorrectly. We had not hit a scraper that actually hit that piece of code, so we just had no idea about it until now. 