### PR TITLE
Add support for custom header fields in android and ios tunnels

### DIFF
--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1299,6 +1299,7 @@ public class LocalTunnel extends CordovaPlugin {
                         "};" +
                         "oReq.open('post', '%s');" +
                         "oReq.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');" +
+                        "oReq.setRequestHeader('X-SunGard-IdP-API-Key', 'SunGard-IdP-Login');" +
                         "oReq.send(JSON.stringify(%s));",
                         url,
                         requestParams.toString()

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1279,9 +1279,18 @@ public class LocalTunnel extends CordovaPlugin {
 
                 Boolean isContentJSON = null;
                 try {
+                    // TODO(ram): check substring instead of equals
                     isContentJSON = requestHeaders.getString("Content-Type").equals("application/json");
                 } catch(JSONException ex) {
                     isContentJSON = false;
+                }
+
+                StringBuilder headersBuilder = new StringBuilder();
+                Iterator<String> keys = requestHeaders.keys();
+                while (keys.hasNext()) {
+                    String key = keys.next();
+                    String v = requestHeaders.getString(k);
+                    headersBuilder.append("oReq.setRequestHeader('" + k + "', '" + v + "');\n");
                 }
 
                 if (method.equals("get")) {
@@ -1298,8 +1307,8 @@ public class LocalTunnel extends CordovaPlugin {
                         "    prompt(JSON.stringify([this.status, 'Load error']), 'gap-iab://requestdone');" +
                         "};" +
                         "oReq.open('post', '%s');" +
-                        "oReq.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');" +
-                        "oReq.setRequestHeader('X-SunGard-IdP-API-Key', 'SunGard-IdP-Login');" +
+                        // "oReq.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');" +
+                        headersBuilder.toString() + 
                         "oReq.send(JSON.stringify(%s));",
                         url,
                         requestParams.toString()

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1289,8 +1289,8 @@ public class LocalTunnel extends CordovaPlugin {
                 Iterator<String> keys = requestHeaders.keys();
                 while (keys.hasNext()) {
                     String key = keys.next();
-                    String v = requestHeaders.getString(k);
-                    headersBuilder.append("oReq.setRequestHeader('" + k + "', '" + v + "');\n");
+                    String value = requestHeaders.getString(key);
+                    headersBuilder.append("oReq.setRequestHeader('" + key + "', '" + value + "');\n");
                 }
 
                 if (method.equals("get")) {

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1287,10 +1287,14 @@ public class LocalTunnel extends CordovaPlugin {
 
                 StringBuilder headersBuilder = new StringBuilder();
                 Iterator<String> keys = requestHeaders.keys();
-                while (keys.hasNext()) {
-                    String key = keys.next();
-                    String value = requestHeaders.getString(key);
-                    headersBuilder.append("oReq.setRequestHeader('" + key + "', '" + value + "');\n");
+                try {
+                    while (keys.hasNext()) {
+                        String key = keys.next();
+                        String value = requestHeaders.getString(key);
+                        headersBuilder.append("oReq.setRequestHeader('" + key + "', '" + value + "');\n");
+                    }
+                } catch (JSONException ex) {
+                    LOG.e(LOG_TAG, "Should never happen", ex);
                 }
 
                 if (method.equals("get")) {

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1311,7 +1311,6 @@ public class LocalTunnel extends CordovaPlugin {
                         "    prompt(JSON.stringify([this.status, 'Load error']), 'gap-iab://requestdone');" +
                         "};" +
                         "oReq.open('post', '%s');" +
-                        // "oReq.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');" +
                         headersBuilder.toString() + 
                         "oReq.send(JSON.stringify(%s));",
                         url,

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -228,7 +228,14 @@ protocol WebViewPropagateDelegate {
             isContentJSON = true
         }
 
-        var requestOptions = RequestOptions(blockNonEssentialRequests: passedBlock, displayWebview: displayWebview, isContentJSON: isContentJSON, method: passedMethod, requestType: requestType, url: url)
+        var requestOptions = RequestOptions(
+            blockNonEssentialRequests: passedBlock,
+            displayWebview: displayWebview,
+            isContentJSON: isContentJSON,
+            method: passedMethod,
+            headers: passedHeaders,
+            requestType: requestType,
+            url: url)
 
         if passedOptions["content"] != nil {
             requestOptions.captchaContentHtml = passedOptions["content"] as? String ?? nil


### PR DESCRIPTION
ios implementation tried to make the headers work in all cases. I failed at making the Swift code dry, and realized I really don't know swift at all, in the process.

Android implementation only manages this for the one case where it is necessary. (Injecting headers in the other cases may not be possible).

Both implementations are able to submit security answers in FIS.