### PR TITLE
Update android error response handling and send status code to client

### DIFF
--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1390,7 +1390,7 @@ public class LocalTunnel extends CordovaPlugin {
      * @param status the status code to return to the JavaScript environment
      */
     public void sendRequestDone(int status, String statusText) {
-        if (status >= 200 && status < 400) {
+        if (status >= 100 && status < 600) {
             try {
                 org.json.JSONObject obj = new JSONObject();
                 obj.put("type", HTTP_REQUEST_DONE);

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1663,6 +1663,10 @@ public class LocalTunnel extends CordovaPlugin {
 
             LOG.d(LOG_TAG, "PAGE FINISHED: " + url);
             if (url.equals(requestUrl)) {
+                // Note: Android APIs don't give us a way to access the real HTTP response code, so
+                // in this case we always return 200. It may be possible to get the real status code
+                // only for >= 400 and only in API Level >= 23.
+                // https://stackoverflow.com/questions/11889020/get-http-status-code-in-android-webview
                 sendRequestDone(200, "");
                 requestUrl = null;
                 enableRequestBlocking = false;
@@ -1685,6 +1689,9 @@ public class LocalTunnel extends CordovaPlugin {
 
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
             super.onReceivedError(view, errorCode, description, failingUrl);
+
+            // Note: errorCode corresponds to an ERROR_* constant in the range of ~ [-16,4]
+            // https://developer.android.com/reference/android/webkit/WebViewClient#constants_1
             sendRequestDone(errorCode, description);
         }
 

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1397,6 +1397,7 @@ public class LocalTunnel extends CordovaPlugin {
                 String cookies = CookieManager.getInstance().getCookie(requestUrl);
                 obj.put("cookies", cookies);
                 obj.put("url", requestUrl);
+                obj.put("status", status);
                 sendUpdate(obj, true);
             } catch (JSONException ex) {
                 LOG.e(LOG_TAG, "Should never happen", ex);

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -296,7 +296,7 @@ protocol WebViewPropagateDelegate {
 
             self.webViewController?.getCookiesForUrl(currentURL ?? "", completionHandler: {cookies in
                 let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: [
-                    "code": self.requestStatus ?? 200,
+                    "status": self.requestStatus ?? 200,
                     "cookies": convertCookiesToString(cookies),
                     "type": "requestdone",
                     "url": currentURL,


### PR DESCRIPTION
Issue 1: Currently the android implementation uses the `LOAD_ERROR_EVENT` route for requests with a response code of >= 400 and therefore the [js client](https://github.com/propelinc/freshebt-vue/blob/master/src/services/localtunnel.ts#L179) doesn't process the actual response body, which may contain information the app needs. For the [fis autogen scraper](https://github.com/propelinc/freshebt-server/blob/master/ebtbalance/scraper_fis_autogen.py#L691), both "invalid card number" and "inactive card" are returned with a 400 and we need the response body to determine how to respond to the user.

Fix 1: send all valid http response codes through the "success" path rather than the "error" path, so the response body will be processed by the js client and passed onto the server. (Note this only applies to JSON POST requests that use the custom AJAX WebView approach, as the native WebView doesn't provide the real response code. All other requests either always return a 200 or an error code between -16 and 4 (added a comment about this).)

Issue 2: The response code on the success path is not sent correctly for either LT version. On the server, if we try to read response code ~~such as in the [LaEbtScraper](https://github.com/propelinc/freshebt-server/blob/master/ebtbalance/scraper_la.py#L44)~~ such as in [XeroxEbtScraper](https://github.com/propelinc/freshebt-server/blob/master/ebtbalance/scraper_xerox.py#L919), this is not working at the moment. 

Fix 2: add the field in the android success message and use the right name for the iOS version.

Note this fix will only work for JSON POST requests in the android version as described above - as all other requests get a 200 regardless of the actual response.

Corresponding server PR: [1638](https://github.com/propelinc/freshebt-server/pull/1638)
Corresponding client PR (to update LT version): [629](https://github.com/propelinc/freshebt-vue/pull/629)

We should do some thorough manual QA for these changes.