### PR TITLE
Selective request blocking by file extension

### DIFF
--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -624,8 +624,6 @@ public class LocalTunnel extends CordovaPlugin {
         lastRequestUrl = null;
         enableRequestBlocking = false;
 
-        LOG.d(LOG_TAG, "showWebPage called: " + url);
-
         if (features != null) {
             String show = features.get(LOCATION);
             if (show != null) {
@@ -1192,8 +1190,6 @@ public class LocalTunnel extends CordovaPlugin {
         enableRequestBlocking = requestOptions.getBoolean("enable_request_blocking");
         String passedFileExtensions = requestOptions.optString("file_extensions_to_block", "");
         requestBlockPattern = getRequestBlockPattern(passedFileExtensions);
-        
-        LOG.d(LOG_TAG, "makeHttpRequest called: " + url + ", passedFileExtensions: " + passedFileExtensions + ", enableRequestBlocking: " + enableRequestBlocking);
 
         if (features != null) {
             String hidden = features.get(HIDDEN);
@@ -1436,8 +1432,6 @@ public class LocalTunnel extends CordovaPlugin {
      * @param status the status code to return to the JavaScript environment
      */
     public void sendRequestDone(int status, String statusText) {
-        LOG.d(LOG_TAG, "sendRequestDone called. status: " + status + ". statusText: " + statusText);
-
         if (status >= 100 && status < 600) {
             try {
                 org.json.JSONObject obj = new JSONObject();
@@ -1528,7 +1522,7 @@ public class LocalTunnel extends CordovaPlugin {
          */
         @Override
         public WebResourceResponse shouldInterceptRequest (final WebView webView, String url) {
-            LOG.d(LOG_TAG, "INSPECTING REQUEST in shouldInterceptRequest(). requestUrl: " + requestUrl + ". url: " + url + ". enableRequestBlocking: " + enableRequestBlocking);
+            LOG.d(LOG_TAG, "INSPECTING REQUEST. requestUrl: " + requestUrl + ". url: " + url + ". enableRequestBlocking: " + enableRequestBlocking);
 
             try {
                 if ((enableRequestBlocking && !requestUrl.equals(url)) || isBlockedByPattern(url)) {
@@ -1751,7 +1745,6 @@ public class LocalTunnel extends CordovaPlugin {
 
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
             LOG.d(LOG_TAG, "RECEIVED ERROR. errorCode: " + errorCode + ". description: " + description + ". failingUrl: " + failingUrl);
-
             super.onReceivedError(view, errorCode, description, failingUrl);
 
             // Note: errorCode corresponds to an ERROR_* constant in the range of ~ [-16,4]

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1374,8 +1374,8 @@ public class LocalTunnel extends CordovaPlugin {
         if (!extensions.isEmpty()) {
             String[] fileExtensions = extensions.split(",");
             StringBuilder patternBuilder = new StringBuilder();
-            patternBuilder.append("(.+)(");
-
+            
+            patternBuilder.append("(");
             for (int i = 0; i < fileExtensions.length; i++) {
                 patternBuilder.append("\\.");
                 patternBuilder.append(fileExtensions[i]);
@@ -1383,7 +1383,8 @@ public class LocalTunnel extends CordovaPlugin {
                     patternBuilder.append("|");
                 }
             }
-            patternBuilder.append(")(\\?.*)?");
+            patternBuilder.append(")");
+            patternBuilder.append("(\\?.*)?$");
 
             try {
                 return Pattern.compile(patternBuilder.toString(), Pattern.CASE_INSENSITIVE);

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -618,6 +618,8 @@ public class LocalTunnel extends CordovaPlugin {
         lastRequestUrl = null;
         enableRequestBlocking = false;
 
+        LOG.d(LOG_TAG, "showWebPage called: " + url);
+
         if (features != null) {
             String show = features.get(LOCATION);
             if (show != null) {
@@ -1183,6 +1185,8 @@ public class LocalTunnel extends CordovaPlugin {
         openWindowHidden = true;
         enableRequestBlocking = requestOptions.getBoolean("enable_request_blocking");
 
+        LOG.d(LOG_TAG, "makeHttpRequest called: " + url + ", enableRequestBlocking: " + enableRequestBlocking);
+
         if (features != null) {
             String hidden = features.get(HIDDEN);
             if (hidden != null && hidden.equals("no")) {
@@ -1390,6 +1394,8 @@ public class LocalTunnel extends CordovaPlugin {
      * @param status the status code to return to the JavaScript environment
      */
     public void sendRequestDone(int status, String statusText) {
+        LOG.d(LOG_TAG, "sendRequestDone called. status: " + status + ". statusText: " + statusText);
+
         if (status >= 100 && status < 600) {
             try {
                 org.json.JSONObject obj = new JSONObject();
@@ -1480,6 +1486,8 @@ public class LocalTunnel extends CordovaPlugin {
          */
         @Override
         public WebResourceResponse shouldInterceptRequest (final WebView webView, String url) {
+            LOG.d(LOG_TAG, "INSPECTING REQUEST in shouldInterceptRequest(). requestUrl: " + requestUrl + ". url: " + url + ". enableRequestBlocking: " + enableRequestBlocking);
+
             try {
                 if (enableRequestBlocking && !requestUrl.equals(url)) {
                     LOG.d(LOG_TAG, "REQUEST BLOCKED: " + url);
@@ -1688,6 +1696,8 @@ public class LocalTunnel extends CordovaPlugin {
         }
 
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+            LOG.d(LOG_TAG, "RECEIVED ERROR. errorCode: " + errorCode + ". description: " + description + ". failingUrl: " + failingUrl);
+
             super.onReceivedError(view, errorCode, description, failingUrl);
 
             // Note: errorCode corresponds to an ERROR_* constant in the range of ~ [-16,4]

--- a/src/android/LocalTunnel.java
+++ b/src/android/LocalTunnel.java
@@ -1371,7 +1371,6 @@ public class LocalTunnel extends CordovaPlugin {
      * @param extensions comma seperated list of file extensions
      */
     protected Pattern getRequestBlockPattern(String extensions) {
-        Pattern result;
         if (!extensions.isEmpty()) {
             String[] fileExtensions = extensions.split(",");
             StringBuilder patternBuilder = new StringBuilder();
@@ -1387,16 +1386,15 @@ public class LocalTunnel extends CordovaPlugin {
             patternBuilder.append(")(\\?.*)?");
 
             try {
-                result = Pattern.compile(patternBuilder.toString() , Pattern.CASE_INSENSITIVE);
+                return Pattern.compile(patternBuilder.toString(), Pattern.CASE_INSENSITIVE);
             }
             catch (PatternSyntaxException ex) {
                 LOG.e(LOG_TAG, "Failed to compile request blocking pattern for extensions: " + extensions, ex);
-                result = Pattern.compile(DEFAULT_REQUEST_BLOCK_PATTERN);
+                return Pattern.compile(DEFAULT_REQUEST_BLOCK_PATTERN);
             }
         } else {
-            result = Pattern.compile(DEFAULT_REQUEST_BLOCK_PATTERN);
+            return Pattern.compile(DEFAULT_REQUEST_BLOCK_PATTERN);
         }
-        return result;
     }
 
     /**

--- a/src/android/LocalTunnelChromeClient.java
+++ b/src/android/LocalTunnelChromeClient.java
@@ -123,6 +123,8 @@ public class LocalTunnelChromeClient extends WebChromeClient {
                 }
 
                 if (scriptCallbackId.startsWith("LocalTunnel")) {
+                    LOG.d(LOG_TAG, "Handling LocalTunnel");
+
                     this.webView.sendPluginResult(scriptResult, scriptCallbackId);
                     result.confirm("");
                     return true;
@@ -130,6 +132,9 @@ public class LocalTunnelChromeClient extends WebChromeClient {
                     try {
                         int status = jsonMessage.getInt(0);
                         String statusText = jsonMessage.getString(1);
+
+                        LOG.d(LOG_TAG, "Handling requestdone. status: " + status + ". statusText: " + statusText);
+
                         this.iab.sendRequestDone(status, statusText);
                     } catch (JSONException e) {
                         LOG.w(LOG_TAG, e.getMessage());

--- a/src/android/LocalTunnelChromeClient.java
+++ b/src/android/LocalTunnelChromeClient.java
@@ -123,8 +123,6 @@ public class LocalTunnelChromeClient extends WebChromeClient {
                 }
 
                 if (scriptCallbackId.startsWith("LocalTunnel")) {
-                    LOG.d(LOG_TAG, "Handling LocalTunnel");
-
                     this.webView.sendPluginResult(scriptResult, scriptCallbackId);
                     result.confirm("");
                     return true;
@@ -132,9 +130,6 @@ public class LocalTunnelChromeClient extends WebChromeClient {
                     try {
                         int status = jsonMessage.getInt(0);
                         String statusText = jsonMessage.getString(1);
-
-                        LOG.d(LOG_TAG, "Handling requestdone. status: " + status + ". statusText: " + statusText);
-
                         this.iab.sendRequestDone(status, statusText);
                     } catch (JSONException e) {
                         LOG.w(LOG_TAG, e.getMessage());

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -510,18 +510,12 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
         webConfiguration.websiteDataStore = webStore
 
         let rules = getBlockRulesForOptions(requestOptions: requestOptions)
-
-        if (!rules.isEmpty) {
-            WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList: rules, completionHandler: {contentRuleList, error in
-                if contentRuleList != nil {
-                    webConfiguration.userContentController.add(contentRuleList!)
-                }
-                self.createWebViewWithConfiguration(requestOptions, webConfiguration, completionHandler)
-            })
-
-        } else {
+        WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList: rules, completionHandler: {contentRuleList, error in
+            if contentRuleList != nil {
+                webConfiguration.userContentController.add(contentRuleList!)
+            }
             self.createWebViewWithConfiguration(requestOptions, webConfiguration, completionHandler)
-        }
+        })
     }
 
     func updateWebView(_ requestOptions: RequestOptions, completionHandler: @escaping () -> Void) {
@@ -529,7 +523,6 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
 
         let rules = getBlockRulesForOptions(requestOptions: requestOptions)
         WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList: rules, completionHandler: {contentRuleList, error in
-
             self.webView.configuration.userContentController.removeAllContentRuleLists()
 
             if contentRuleList != nil {
@@ -558,7 +551,7 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
         for ext in extensions {
             blockRulesDict.append([
                 "trigger": [
-                    "url-filter": "(.+)(\\.\(ext))(\\?.*)?",
+                    "url-filter": "\\.\(ext)(\\?.*)?$",
                 ],
                 "action": [
                     "type": "block",

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -542,7 +542,7 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
     private func getBlockRulesForOptions(requestOptions: RequestOptions) -> String {
         if (requestOptions.blockNonEssentialRequests) {
             return self.blockRules
-        } else if (!requestOptions.fileExtensionsToBlock.isEmpty && requestOptions.requestType != CAPTCHA_REQUEST) {
+        } else if (!requestOptions.fileExtensionsToBlock.isEmpty) {
             return getBlockRulesForFileExtensions(extensions: requestOptions.fileExtensionsToBlock)
         }
         return "[]"

--- a/src/ios/CDVWKLocalTunnel.swift
+++ b/src/ios/CDVWKLocalTunnel.swift
@@ -30,6 +30,7 @@ let CAPTCHA_REQUEST = "_captcha"
 
 struct RequestOptions {
     var blockNonEssentialRequests: Bool
+    var fileExtensionsToBlock: [String]
     var displayWebview: Bool
     var isContentJSON: Bool
     var method: String
@@ -234,6 +235,8 @@ protocol WebViewPropagateDelegate {
         let displayWebview =  windowFeatures == "hidden=no" || passedHidden == false
 
         let passedBlock = passedOptions["enable_request_blocking"] as? Bool ?? false
+        let passedFileExtensions = passedOptions["file_extensions_to_block"] as? String ?? ""
+        let fileExtensionsToBlock = !passedFileExtensions.isEmpty ? passedFileExtensions.components(separatedBy: ",") : []
 
         let passedMethod = passedOptions["method"] as? String ?? "GET"
 
@@ -252,6 +255,7 @@ protocol WebViewPropagateDelegate {
 
         var requestOptions = RequestOptions(
             blockNonEssentialRequests: passedBlock,
+            fileExtensionsToBlock: fileExtensionsToBlock,
             displayWebview: displayWebview,
             isContentJSON: isContentJSON,
             method: passedMethod,
@@ -505,8 +509,10 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
         let webStore = WKWebsiteDataStore.nonPersistent()
         webConfiguration.websiteDataStore = webStore
 
-        if (requestOptions.blockNonEssentialRequests) {
-            WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList:self.blockRules , completionHandler: {contentRuleList, error in
+        let rules = getBlockRulesForOptions(requestOptions: requestOptions)
+
+        if (!rules.isEmpty) {
+            WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList: rules, completionHandler: {contentRuleList, error in
                 if contentRuleList != nil {
                     webConfiguration.userContentController.add(contentRuleList!)
                 }
@@ -521,8 +527,8 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
     func updateWebView(_ requestOptions: RequestOptions, completionHandler: @escaping () -> Void) {
         self.webView.customUserAgent = requestOptions.userAgent
 
-        let rules = requestOptions.blockNonEssentialRequests == true ? self.blockRules : "[]"
-        WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList:rules, completionHandler: {contentRuleList, error in
+        let rules = getBlockRulesForOptions(requestOptions: requestOptions)
+        WKContentRuleListStore.default()?.compileContentRuleList(forIdentifier: "block_rules", encodedContentRuleList: rules, completionHandler: {contentRuleList, error in
 
             self.webView.configuration.userContentController.removeAllContentRuleLists()
 
@@ -531,6 +537,35 @@ class WebViewViewController: UIViewController, URLSessionTaskDelegate, WKNavigat
             }
             completionHandler()
         })
+    }
+
+    private func getBlockRulesForOptions(requestOptions: RequestOptions) -> String {
+        if (requestOptions.blockNonEssentialRequests) {
+            return self.blockRules
+        } else if (!requestOptions.fileExtensionsToBlock.isEmpty && requestOptions.requestType != CAPTCHA_REQUEST) {
+            return getBlockRulesForFileExtensions(extensions: requestOptions.fileExtensionsToBlock)
+        }
+        return "[]"
+    }
+
+    private func getBlockRulesForFileExtensions(extensions: [String]) -> String {
+        // Note (Jeff) 1/20/21 - the "url-filter" only supports a subset of regular expression functionality,
+        // not including the "logical or" operator (|). So  we need to build the rules one per per file extension
+        // at a time, rather than building one comprehesive regex. 
+        // ref: https://webkit.org/blog/3476/content-blockers-first-look/
+        var blockRulesDict: [[String: Any]] = []
+
+        for ext in extensions {
+            blockRulesDict.append([
+                "trigger": [
+                    "url-filter": "(.+)(\\.\(ext))(\\?.*)?",
+                ],
+                "action": [
+                    "type": "block",
+                ],
+            ])
+        }
+        return jsonDumps(blockRulesDict) ?? "[]"
     }
 
     func close() {


### PR DESCRIPTION
Background: the local tunnel session request has a property called `enable_request_blocking`, which when enabled informs the localtunnel that it should block requests for anything other than the requested resource. Setting it to false enables _web driving_ in which the session webview will load all additional resources and interact with the page using javascript.

This PR introduces a new request property called `file_extensions_to_block`, which allows selective blocking of non-essential resources like images, stylesheets, etc based on the URL file extension, while still allowing web driving.

This change was started during the December 2020 eng hackathon. Presentation and estimated bandwidth savings are available at https://docs.google.com/presentation/d/1JpjQ1j4y2xIh2DNLTrwC4S7Mx8zI7ldNtcfYsAmtlFk/edit

Testing notes
- Validated that FIS and Xerox syncs still work as expected with target requests omitted, on iOS and Android emulators
- Need to confirm that Xerox captcha flows still work as expected. Could not successfully replicate this flow in the emulators, either with or without the changes

Client PR: https://github.com/propelinc/freshebt-vue/pull/646
Server PR: https://github.com/propelinc/freshebt-server/pull/1671